### PR TITLE
Candlesticks implementation

### DIFF
--- a/lib/klines/dune
+++ b/lib/klines/dune
@@ -1,4 +1,4 @@
 (library
  (name klines)
  (libraries lwt lwt.unix conduit-lwt-unix ezjsonm cohttp cohttp-lwt cohttp-lwt-unix tls ssl)
- (flags (:standard -w -67)))
+ (flags (:standard -w -67-69-32)))

--- a/lib/klines/klines.ml
+++ b/lib/klines/klines.ml
@@ -1,0 +1,97 @@
+module type CandleStick = sig
+  type candlestick
+  val endpoint : string
+  val interval : string
+  val get_candlesticks : unit -> candlestick list
+  val print_candlesticks : candlestick list -> unit
+end;;
+
+module Make(Endpoint : sig val klines_url : string end)(Pair : sig val symbol : string end) (Interval : sig val size : string end) : CandleStick = struct
+  type candlestick = {
+    open_time : int;
+    open_price : float;
+    high_price : float;
+    low_price : float;
+    close_price : float;
+    volume : float;
+    close_time : int;
+    quote_asset_volume : float;
+    number_of_trades : int;
+    taker_buy_base_asset_volume : float;
+    taker_buy_quote_asset_volume : float
+  };;
+
+  let endpoint = Endpoint.klines_url ^ "?symbol=" ^ Pair.symbol ^ "&interval=" ^ Interval.size;;
+
+  let interval = Interval.size;;
+
+  let get_json_from_api_url endpoint = 
+    let ezjsonm =
+      Lwt.bind
+        (Cohttp_lwt_unix.Client.get (Uri.of_string endpoint))
+        (fun (_, body) ->
+           Lwt.bind (Cohttp_lwt.Body.to_string body) (fun body_string ->
+               let json = Ezjsonm.from_string body_string in
+               Lwt.return json))
+    in
+    Lwt_main.run ezjsonm;;
+
+  let get_data = function
+    |[`Float open_time; `String open_price; `String high_price; `String low_price;
+      `String close_price; `String volume; `Float close_time; `String quote_asset_volume;
+      `Float number_of_trades; `String taker_buy_base_asset_volume; `String taker_buy_quote_asset_volume; _] -> 
+      {
+        open_time = (int_of_float open_time);
+        open_price = (float_of_string open_price);
+        high_price = (float_of_string high_price);
+        low_price = (float_of_string low_price);
+        close_price = (float_of_string close_price);
+        volume = (float_of_string volume);
+        close_time = (int_of_float close_time);
+        quote_asset_volume = (float_of_string quote_asset_volume);
+        number_of_trades = (int_of_float number_of_trades);
+        taker_buy_base_asset_volume = (float_of_string taker_buy_base_asset_volume);
+        taker_buy_quote_asset_volume = (float_of_string taker_buy_quote_asset_volume)
+      }
+    |_ -> 
+      {
+        open_time = 0;
+        open_price = 0.0;
+        high_price = 0.0;
+        low_price = 0.0;
+        close_price = 0.0;
+        volume = 0.0;
+        close_time = 0;
+        quote_asset_volume = 0.0;
+        number_of_trades = 0;
+        taker_buy_base_asset_volume = 0.0;
+        taker_buy_quote_asset_volume = 0.0
+      };; 
+
+  let parse_kline_data json  = let rec parse_kline_data' json acc = match json with
+      |`A (`A head :: tail) -> parse_kline_data' (`A tail) ((get_data head) :: acc)
+      |_ -> acc in parse_kline_data' json [];;
+
+  let get_candlesticks () = parse_kline_data (get_json_from_api_url endpoint);;
+
+  let print_candlestick = function
+    |{
+      open_time;
+      open_price;
+      high_price;
+      low_price;
+      close_price;
+      volume;
+      close_time;
+      quote_asset_volume;
+      number_of_trades;
+      taker_buy_base_asset_volume;
+      taker_buy_quote_asset_volume
+    } -> Printf.printf "%i %0.2f %0.2f %0.2f %0.2f %0.2f %i %0.2f %i %0.2f %0.2f" open_time open_price high_price low_price close_price volume
+           close_time quote_asset_volume number_of_trades taker_buy_base_asset_volume taker_buy_quote_asset_volume
+
+  let print_candlesticks candlestick_list = let rec print_inner_lists' candlestick_list = match candlestick_list with
+      |[] -> ()
+      |l0::ln -> print_candlestick l0 ; print_newline (); print_inner_lists' ln in print_inner_lists' candlestick_list;;
+  ;;
+end

--- a/lib/klines/klines.mli
+++ b/lib/klines/klines.mli
@@ -1,0 +1,11 @@
+module type CandleStick = sig
+  type candlestick
+  val endpoint : string
+  val interval : string
+  val get_candlesticks : unit -> candlestick list
+  val print_candlesticks : candlestick list -> unit
+end  
+
+module Make : functor (Endpoint : sig val klines_url : string end)
+                        (Pair : sig val symbol : string end) 
+                        (Interval : sig val size : string end) -> CandleStick

--- a/lib/price/price.ml
+++ b/lib/price/price.ml
@@ -3,9 +3,8 @@ module type Price' = sig
   val get_price : unit -> float
 end
 
-module Make(Endpoint : sig val price_url: string end)(Pair : sig val pair : string end) : Price' = struct
-  let endpoint = Endpoint.price_url ^ "?symbol=" ^ Pair.pair;;
-  let json_to_float json = let price_string = Ezjsonm.(get_string (find json ["price"])) in float_of_string price_string;;
+module Make(Endpoint : sig val price_url: string end)(Pair : sig val symbol : string end) : Price' = struct
+  let endpoint = Endpoint.price_url ^ "?symbol=" ^ Pair.symbol;;
 
   let get_json_from_api_url endpoint = let ezjsonm =
                                          Lwt.bind
@@ -16,6 +15,8 @@ module Make(Endpoint : sig val price_url: string end)(Pair : sig val pair : stri
                                                   Lwt.return json))
     in
     Lwt_main.run ezjsonm;;
+
+  let json_to_float json = let price_string = Ezjsonm.(get_string (find json ["price"])) in float_of_string price_string;;
 
   let get_price () = json_to_float (get_json_from_api_url endpoint);;
 end

--- a/lib/price/price.mli
+++ b/lib/price/price.mli
@@ -2,4 +2,4 @@ module type Price' =
   sig val endpoint : string val get_price : unit -> float end
 module Make :
   functor (Endpoint : sig val price_url : string end)
-    (Pair : sig val pair : string end) -> Price'
+    (Pair : sig val symbol : string end) -> Price'

--- a/test/binance_ocaml_api.ml
+++ b/test/binance_ocaml_api.ml
@@ -1,8 +1,8 @@
-
 let library_unit_testing () =
   let open Alcotest in run "Module Endoints" [
     Utilities_test.suite ();
-    Price_test.suite ()
+    Price_test.suite ();
+    Klines_test.suite ()
   ];;
 
 library_unit_testing ();;

--- a/test/dune
+++ b/test/dune
@@ -1,3 +1,3 @@
 (test
  (name binance_ocaml_api)
- (libraries lib alcotest utilities_test price_test))
+ (libraries lib alcotest utilities_test price_test klines_test))

--- a/test/klines/dune
+++ b/test/klines/dune
@@ -1,0 +1,3 @@
+(library
+ (name klines_test)
+ (libraries lib alcotest))

--- a/test/klines/klines_test.ml
+++ b/test/klines/klines_test.ml
@@ -1,0 +1,23 @@
+open Lib;;
+open Alcotest;;
+
+module Enpoints = Utilities.Make(struct let api = Utilities.BaseApis.api_default end);;
+
+module BitcoinCandlesticks = Klines.Make(struct let klines_url = Enpoints.klines end)(struct let symbol = "BTCUSDT" end)(struct let size = "5m" end);;
+module MultiversXCandlesticks = Klines.Make(struct let klines_url = Enpoints.klines end)(struct let symbol = "EGLDUSDT" end)(struct let size = "5m" end);;
+module PolkadotCandlesticks = Klines.Make(struct let klines_url = Enpoints.klines end)(struct let symbol = "DOTUSDT" end)(struct let size = "5m" end);;
+
+
+let bitcoin_candlesticks = BitcoinCandlesticks.get_candlesticks ();;
+let multiversx_candlesticks = MultiversXCandlesticks.get_candlesticks ();;
+let polkadot_candlesticks = PolkadotCandlesticks.get_candlesticks ();; 
+
+let bitcoin_candlesticks_size () = check int "Bitcoin number of candlesticks" ((List.length (bitcoin_candlesticks))) 500;;
+let multiversx_candlesticks_size () = check int "MultiversX number of candlesticks" ((List.length (multiversx_candlesticks))) 500;;
+let polkadot_candlesticks_size () = check int "Polkadot number of candlesticks" ((List.length (polkadot_candlesticks))) 500;;
+
+let suite () = "Klines", [
+    test_case "Bitcoin number of candlesticks" `Quick bitcoin_candlesticks_size;
+    test_case "MultiversX number of candlesticks" `Quick multiversx_candlesticks_size;
+    test_case "Polkadot number of candlesticks" `Quick polkadot_candlesticks_size
+  ];; 

--- a/test/klines/klines_test.mli
+++ b/test/klines/klines_test.mli
@@ -1,0 +1,1 @@
+val suite : unit -> string * unit Alcotest.test_case list

--- a/test/price/price_test.ml
+++ b/test/price/price_test.ml
@@ -3,7 +3,7 @@ open Alcotest;;
 
 module Enpoints = Utilities.Make(struct let api = Utilities.BaseApis.api_default end);;
 
-module Bitcoin = Price.Make(struct let price_url = Enpoints.ticker_price end) (struct let pair = "BTCUSDT" end);; 
+module Bitcoin = Price.Make(struct let price_url = Enpoints.ticker_price end) (struct let symbol = "BTCUSDT" end);; 
 
 let bitcoin_price () = check bool "Bitcoin price" true (Bitcoin.get_price () > 20000.0);;
 


### PR DESCRIPTION
This pull reuqest brings the features below to the main branch.

The data from Binance Klines are stored in a record type that matchs with the list of Kline from Binance.

I created a module signature Candlesticks that defines the type Candlestick and his functions. It can be created with the functor Make that have 3 inputs, the endpoint, the pair (symbol) and the interval of a candlestick.

Unit testing the size of candlestick list.