### PR TITLE
New response type and some refactoring for better performance have done.

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -33,9 +33,9 @@
  (depends ocaml dune))
 
 (package
- (name response)
+ (name error_code)
  (synopsis
-  "Contains modules for holding the responses from Binance API inside records")
+  "Contains modules for holding the error codes from Binance API inside a record.")
  (depends ocaml dune))
 
 (package

--- a/lib/binance_ocaml_api.ml
+++ b/lib/binance_ocaml_api.ml
@@ -1,6 +1,6 @@
+module Error_code = Error_code
 module Margin_account = Margin_account
 module Market_data_endpoints = Market_data_endpoints
-module Response = Response
 module Spot_account = Spot_account
 module Spot_trading = Spot_trading
 module Utilities = Utilities

--- a/lib/binance_ocaml_api.mli
+++ b/lib/binance_ocaml_api.mli
@@ -1,6 +1,6 @@
+module Error_code = Error_code
 module Margin_account = Margin_account
 module Market_data_endpoints = Market_data_endpoints
-module Response = Response
 module Spot_account = Spot_account
 module Spot_trading = Spot_trading
 module Utilities = Utilities

--- a/lib/dune
+++ b/lib/dune
@@ -4,9 +4,9 @@
  (name binance_ocaml_api)
  (public_name binance_ocaml_api)
  (libraries
+  error_code
   margin_account
   market_data_endpoints
-  response
   spot_account
   spot_trading
   utilities

--- a/lib/error_code/dune
+++ b/lib/error_code/dune
@@ -1,9 +1,9 @@
 (include_subdirs unqualified)
 
 (library
- (name response)
- (public_name response)
- (modules response error_code)
+ (name error_code)
+ (public_name error_code)
+ (modules error_code)
  (libraries decimal lwt utilities variants)
  (flags
   (:standard -w -32-34-37-67-69)))

--- a/lib/error_code/error_code.ml
+++ b/lib/error_code/error_code.ml
@@ -1,4 +1,4 @@
-type error_code = {
+type t = {
   code : Decimal.t;
   msg : string
 };;

--- a/lib/error_code/error_code.ml
+++ b/lib/error_code/error_code.ml
@@ -7,18 +7,20 @@ let get = function
   |`O[
       ("code", `Float code);
       ("msg", `String msg)
-    ] -> Some {
+    ] -> {
       code = Decimal.of_int (int_of_float code);
       msg = msg
     }
-  |_ -> None;;
+  |_ -> {
+      code = Decimal.of_int (-1001);
+      msg = "Error code default value, something went worng, please check manually the API response!"
+    };;
 
 let printl = function
-  |Some {
-      code = code;
-      msg = msg
-    } -> let open Lwt.Syntax in
+  |{
+    code = code;
+    msg = msg
+  } -> let open Lwt.Syntax in
     let* () = Lwt_io.printf "code = %s\n" (Decimal.to_string code) in
     let* () = Lwt_io.printf "msg = %s\n\n" msg in
-    Lwt.return ()
-  |None -> Lwt.return ();;
+    Lwt.return ();;

--- a/lib/error_code/error_code.ml
+++ b/lib/error_code/error_code.ml
@@ -12,7 +12,7 @@ let get = function
       msg = msg
     }
   |_ -> {
-      code = Decimal.of_int (-1001);
+      code = Decimal.of_int (-0001);
       msg = "Error code default value, something went worng, please check manually the API response!"
     };;
 

--- a/lib/error_code/error_code.mli
+++ b/lib/error_code/error_code.mli
@@ -4,4 +4,5 @@ type error_code = {
 };;
 
 val get : [> Ezjsonm.t] -> error_code
+
 val printl : error_code -> unit Lwt.t

--- a/lib/error_code/error_code.mli
+++ b/lib/error_code/error_code.mli
@@ -1,0 +1,7 @@
+type error_code = {
+  code : Decimal.t;
+  msg : string
+};;
+
+val get : [> Ezjsonm.t] -> error_code
+val printl : error_code -> unit Lwt.t

--- a/lib/error_code/error_code.mli
+++ b/lib/error_code/error_code.mli
@@ -1,8 +1,8 @@
-type error_code = {
+type t = {
   code : Decimal.t;
   msg : string
 };;
 
-val get : [> Ezjsonm.t] -> error_code
+val get : [> Ezjsonm.t] -> t
 
-val printl : error_code -> unit Lwt.t
+val printl : t -> unit Lwt.t

--- a/lib/market_data_endpoints/current_average_price/current_average_price.ml
+++ b/lib/market_data_endpoints/current_average_price/current_average_price.ml
@@ -10,11 +10,11 @@ let get_data = function
   |`O[
       ("mins", `Float mins);
       ("price", `String price)
-    ] -> Some {
+    ] -> Ok {
       mins = Decimal.of_string (string_of_float mins);
       price = Decimal.of_string price
     }
-  |_ -> None;;
+  |error -> Error (Error_code.get error);;
 
 let parse_data json = json >>= fun json' -> Lwt.return (get_data json');;
 

--- a/lib/market_data_endpoints/current_average_price/current_average_price.mli
+++ b/lib/market_data_endpoints/current_average_price/current_average_price.mli
@@ -3,4 +3,4 @@ type t = {
   price : Decimal.t
 };;
 
-val get : base_url:string -> endpoint:string -> parameters:(string * string) list -> t option Lwt.t
+val get : base_url:string -> endpoint:string -> parameters:(string * string) list -> (t, Error_code.t) result Lwt.t

--- a/lib/market_data_endpoints/dune
+++ b/lib/market_data_endpoints/dune
@@ -19,6 +19,7 @@
   cohttp-lwt-unix
   conduit-lwt-unix
   decimal
+  error_code
   ezjsonm
   lwt
   lwt.unix

--- a/lib/market_data_endpoints/old_trade_lookup/old_trade_lookup.ml
+++ b/lib/market_data_endpoints/old_trade_lookup/old_trade_lookup.ml
@@ -21,7 +21,7 @@ let get_data = function
       ("time", `Float time);
       ("isBuyerMaker", `Bool is_buyer_maker);
       ("isBestMatch", `Bool is_best_match);
-    ] -> Some {
+    ] -> Ok {
       id = Decimal.of_string (string_of_float id);
       price = Decimal.of_string price;
       qty = Decimal.of_string qty;
@@ -30,10 +30,10 @@ let get_data = function
       is_buyer_maker = is_buyer_maker;
       is_best_match = is_best_match
     }
-  |_ -> None;;
+  |error -> Error (Error_code.get error);;
 
 let printl = function
-  |Some {
+  |Ok {
       id = id;
       price = price;
       qty = qty;
@@ -49,7 +49,7 @@ let printl = function
     let* () = Lwt_io.printl (string_of_bool is_buyer_maker) in
     let* () = Lwt_io.printl (string_of_bool is_best_match) in
     Lwt_io.printl ""
-  |None -> Lwt_io.printl "None response!";;
+  |Error error -> Error_code.printl error;;
 
 let print_list t_list = Lwt_list.iter_s (printl) t_list;;
 

--- a/lib/market_data_endpoints/old_trade_lookup/old_trade_lookup.mli
+++ b/lib/market_data_endpoints/old_trade_lookup/old_trade_lookup.mli
@@ -8,8 +8,8 @@ type t = {
   is_best_match : bool
 };;
 
-val printl : t option -> unit Lwt.t
+val printl : (t, Error_code.t) result -> unit Lwt.t
 
-val print_list : t option list -> unit Lwt.t
+val print_list : (t, Error_code.t) result list -> unit Lwt.t
 
-val get : base_url:string -> endpoint:string -> parameters:(string * string) list -> t option list Lwt.t
+val get : base_url:string -> endpoint:string -> parameters:(string * string) list -> (t, Error_code.t) result list Lwt.t

--- a/lib/market_data_endpoints/order_book/order_book.ml
+++ b/lib/market_data_endpoints/order_book/order_book.ml
@@ -16,12 +16,12 @@ let get_depth_data = function
       ("lastUpdateId", `Float last_update_id);
       ("bids", bids);
       ("asks", asks)
-    ] -> Some {
+    ] -> Ok {
       last_update_id = Decimal.of_string (string_of_float last_update_id);
       bids = Data.get_list_from_list get_data bids;
       asks = Data.get_list_from_list get_data asks        
     }
-  |_ -> None;;
+  |error -> Error (Error_code.get error);;
 
 let parse_depth_data json = 
   json >>= fun json' -> Lwt.return(get_depth_data json');; 

--- a/lib/market_data_endpoints/order_book/order_book.mli
+++ b/lib/market_data_endpoints/order_book/order_book.mli
@@ -4,4 +4,4 @@ type t = {
   asks : (Decimal.t * Decimal.t) list
 }
 
-val get_depth : base_url:string -> endpoint:string -> parameters:(string * string) list -> t option Lwt.t
+val get_depth : base_url:string -> endpoint:string -> parameters:(string * string) list -> (t, Error_code.t) result Lwt.t

--- a/lib/market_data_endpoints/recent_trade_list/recent_trade_list.ml
+++ b/lib/market_data_endpoints/recent_trade_list/recent_trade_list.ml
@@ -21,7 +21,7 @@ let get_data = function
       ("time", `Float time);
       ("isBuyerMaker", `Bool is_buyer_maker);
       ("isBestMatch", `Bool is_best_match);
-    ] -> Some {
+    ] -> Ok {
       id = Decimal.of_string (string_of_float id);
       price = Decimal.of_string price;
       qty = Decimal.of_string qty;
@@ -30,10 +30,10 @@ let get_data = function
       is_buyer_maker = is_buyer_maker;
       is_best_match = is_best_match
     }
-  |_ -> None;;
+  |error -> Error (Error_code.get error);;
 
 let printl = function
-  |Some {
+  |Ok {
       id = id;
       price = price;
       qty = qty;
@@ -49,7 +49,7 @@ let printl = function
     let* () = Lwt_io.printl (string_of_bool is_buyer_maker) in
     let* () = Lwt_io.printl (string_of_bool is_best_match) in
     Lwt_io.printl ""
-  |None -> Lwt_io.printl "None response!";;
+  |Error error -> Error_code.printl error;;
 
 let print_list t_list = Lwt_list.iter_s (printl) t_list;;
 

--- a/lib/market_data_endpoints/recent_trade_list/recent_trade_list.mli
+++ b/lib/market_data_endpoints/recent_trade_list/recent_trade_list.mli
@@ -8,10 +8,10 @@ type t = {
   is_best_match : bool
 };;
 
-val get_data : [> Ezjsonm.t] -> t option
+val get_data : [> Ezjsonm.t] -> (t, Error_code.t) result
 
-val printl : t option -> unit Lwt.t
+val printl : (t, Error_code.t) result -> unit Lwt.t
 
-val print_list : t option list -> unit Lwt.t
+val print_list : (t, Error_code.t) result list -> unit Lwt.t
 
-val get : base_url:string -> endpoint:string -> parameters:(string * string) list -> t option list Lwt.t
+val get : base_url:string -> endpoint:string -> parameters:(string * string) list -> (t, Error_code.t) result list Lwt.t

--- a/lib/market_data_endpoints/server_time/server_time.ml
+++ b/lib/market_data_endpoints/server_time/server_time.ml
@@ -1,7 +1,11 @@
 open Utilities;;
 open Lwt.Infix;;
 
-let json_to_time json = json >>= fun json' -> Lwt.return Ezjsonm.(get_int (find json' ["serverTime"]));;
+let get_data = function
+  |`O[("serverTime", `Float server_time)] -> Ok (Decimal.of_int (int_of_float server_time))
+  |error -> Error (Error_code.get error);;
+
+let json_to_time json = json >>= fun json' -> Lwt.return (get_data json');;
 
 let get ~base_url:base_url ~endpoint:endpoint = let url = String.concat "" [base_url; endpoint] in
   json_to_time (Requests.get url);;

--- a/lib/market_data_endpoints/server_time/server_time.mli
+++ b/lib/market_data_endpoints/server_time/server_time.mli
@@ -1,1 +1,1 @@
-val get : base_url:string -> endpoint:string -> int Lwt.t
+val get : base_url:string -> endpoint:string -> (Decimal.t, Error_code.t) result Lwt.t

--- a/lib/market_data_endpoints/symbol_price_ticker/symbol_price_ticker.ml
+++ b/lib/market_data_endpoints/symbol_price_ticker/symbol_price_ticker.ml
@@ -5,8 +5,8 @@ let get_data = function
   |`O[
       ("symbol", `String symbol);
       ("price", `String price)
-    ] -> (Symbol.unwrap symbol, Decimal.of_string price)
-  |_ -> (Symbol.unwrap"ERROR", Decimal.of_int (-1));;
+    ] -> Ok (Symbol.unwrap symbol, Decimal.of_string price)
+  |error -> Error (Error_code.get error);;
 
 let parse_symbol_price json = let open Lwt.Infix in 
   json >>= fun json' -> Lwt.return (get_data json');;

--- a/lib/market_data_endpoints/symbol_price_ticker/symbol_price_ticker.mli
+++ b/lib/market_data_endpoints/symbol_price_ticker/symbol_price_ticker.mli
@@ -1,3 +1,3 @@
 open Variants
 
-val get : base_url:string -> endpoint:string -> parameters:(string * string) list -> (Symbol.t * Decimal.t) Lwt.t
+val get : base_url:string -> endpoint:string -> parameters:(string * string) list -> (Symbol.t * Decimal.t, Error_code.t) result Lwt.t

--- a/lib/market_data_endpoints/test_connectivity/test_connectivity.ml
+++ b/lib/market_data_endpoints/test_connectivity/test_connectivity.ml
@@ -1,7 +1,12 @@
 open Utilities;;
 open Lwt.Infix;;
+
+let get_data = function
+  |`O[] -> Ok "{}"
+  |error -> Error (Error_code.get error);;
+
 let json_to_string json = 
-  json >>= fun json' -> Lwt.return (Ezjsonm.to_string json');;
+  json >>= fun json' -> Lwt.return (get_data json');;
 
 let get ~base_url:base_url ~endpoint:endpoint = let url = String.concat "" [base_url; endpoint] in
   json_to_string (Requests.get url);;

--- a/lib/market_data_endpoints/test_connectivity/test_connectivity.mli
+++ b/lib/market_data_endpoints/test_connectivity/test_connectivity.mli
@@ -1,1 +1,1 @@
-val get : base_url:string -> endpoint:string -> string Lwt.t
+val get : base_url:string -> endpoint:string -> (string, Error_code.t) result Lwt.t

--- a/lib/response/error_code/error_code.mli
+++ b/lib/response/error_code/error_code.mli
@@ -1,7 +1,0 @@
-type error_code = {
-  code : Decimal.t;
-  msg : string
-};;
-
-val get : [> Ezjsonm.t] -> error_code option
-val printl : error_code option -> unit Lwt.t

--- a/lib/response/response.ml
+++ b/lib/response/response.ml
@@ -1,1 +1,0 @@
-module Error_code = Error_code

--- a/lib/response/response.mli
+++ b/lib/response/response.mli
@@ -1,1 +1,0 @@
-module Error_code = Error_code

--- a/lib/spot_account/account/account.mli
+++ b/lib/spot_account/account/account.mli
@@ -16,7 +16,7 @@ type account = {
   taker_commision : Decimal.t;
   buyer_commission : Decimal.t;
   seller_commission : Decimal.t;
-  commission_rates : commission_rate option;
+  commission_rates : (commission_rate, Error_code.t) result;
   can_trade : bool;
   can_withdraw : bool;
   can_deposit : bool;
@@ -25,11 +25,11 @@ type account = {
   prevent_sor : bool;
   update_time : Decimal.t;
   account_type : string;
-  balances : balance option list;
+  balances : (balance, Error_code.t) result list;
   permissions : string list;
   uid : Decimal.t
 };;
 
-val get_account : string -> string -> string -> string -> (string * string) list -> account option Lwt.t;;
+val get_account : string -> string -> string -> string -> (string * string) list -> (account, Error_code.t) result Lwt.t;;
 
-val print_account : account option -> unit Lwt.t
+val print_account : (account, Error_code.t) result -> unit Lwt.t

--- a/lib/spot_account/dune
+++ b/lib/spot_account/dune
@@ -11,11 +11,11 @@
   cohttp-lwt-unix
   conduit-lwt-unix
   decimal
+  error_code
   ezjsonm
   lwt
   lwt.unix
   nocrypto
-  response
   ssl
   tls
   utilities

--- a/lib/spot_trading/dune
+++ b/lib/spot_trading/dune
@@ -11,11 +11,11 @@
   cohttp-lwt-unix
   conduit-lwt-unix
   decimal
+  error_code
   ezjsonm
   lwt
   lwt.unix
   nocrypto
-  response
   ssl
   tls
   utilities

--- a/lib/spot_trading/new_order/new_order.ml
+++ b/lib/spot_trading/new_order/new_order.ml
@@ -1,6 +1,5 @@
 open Utilities;;
 open Lwt.Infix;;
-open Response;;
 open Variants;;
 
 type fill = {

--- a/lib/spot_trading/new_order/new_order.ml
+++ b/lib/spot_trading/new_order/new_order.ml
@@ -10,7 +10,7 @@ type fill = {
   trade_id : Decimal.t
 };;
 
-type ack = {
+type ack_response = {
   symbol : Symbol.t;
   order_id : Decimal.t;
   order_list_id : Decimal.t;
@@ -18,8 +18,8 @@ type ack = {
   transact_time: Decimal.t
 };;
 
-type result = {
-  ack : ack option;
+type result_response = {
+  ack_response : (ack_response, Error_code.t) result;
   price : Decimal.t;
   orig_qty : Decimal.t;
   executed_qty : Decimal.t;
@@ -32,12 +32,12 @@ type result = {
   self_trade_prevention_mode : string
 };;
 
-type full = {
-  result : result option;
-  fills : fill option list
+type full_response = {
+  result_response : (result_response, Error_code.t) result;
+  fills : (fill, Error_code.t) result list
 };;
 
-type new_order_response = Ack of ack option | Result of result option | Full of full option | Error_code of Error_code.error_code option;;
+type new_order_response = Ack of ((ack_response, Error_code.t) result) | Result of ((result_response, Error_code.t) result) | Full of ((full_response, Error_code.t) result);;
 
 let get_fill = function
   |`O[
@@ -46,17 +46,17 @@ let get_fill = function
       ("commission", `String commission);
       ("commissionAsset", `String commission_asset);
       ("tradeId", `Float trade_id)
-    ] -> Some {
+    ] -> Ok {
       price = Decimal.of_string price;
       qty = Decimal.of_string qty;
       commission = Decimal.of_string commission;
       commission_asset = commission_asset;
       trade_id = Decimal.of_int (int_of_float trade_id)
     }
-  |_ -> None;;
+  |error -> Error (Error_code.get error);;
 
 let print_fill = function
-  |Some fill -> begin match fill with
+  |Ok fill -> begin match fill with
         {
           price = price;
           qty = qty;
@@ -66,7 +66,7 @@ let print_fill = function
         } -> let open Decimal in 
         Lwt_io.printf "price = %s\nqty = %s\ncommission = %s\ncommission_asset%s\ntrade_id = %s\n\n" (to_string price) (to_string qty) (to_string commission) (commission_asset) (to_string trade_id)
     end
-  |_ -> Lwt.return ();;
+  |Error error -> Error_code.printl error;;
 
 let print_fills fills = Lwt_list.iter_s (print_fill) fills;;
 
@@ -77,17 +77,17 @@ let get_ack = function
       ("orderListId", `Float order_list_id);
       ("clientOrderId", `String client_order_id);
       ("transactTime", `Float transact_time);
-    ] -> Some { (*Here add Some Ack {ack} or Ack {ack}*)
+    ] -> Ok { (*Here add Some Ack {ack_response} or Ack {ack_response}*)
       symbol = Symbol.unwrap symbol;
       order_id = Decimal.of_int (int_of_float order_id);
       order_list_id = Decimal.of_int (int_of_float order_list_id);
       client_order_id = client_order_id;
       transact_time = Decimal.of_int (int_of_float transact_time)
     }
-  |_ -> None;;
+  |error -> Error (Error_code.get error);;
 
 let print_ack = function
-  |Some ack -> begin match ack with
+  |Ok ack_response -> begin match ack_response with
       |{
         symbol = symbol;
         order_id = order_id;
@@ -102,7 +102,7 @@ let print_ack = function
         let* () = printf "transact_time = %s\n\n" (Decimal.to_string transact_time) in
         Lwt.return ()
     end
-  |None -> Lwt.return ();;
+  |Error error -> Error_code.printl error;;
 
 let get_result = function
   |`O[
@@ -121,8 +121,8 @@ let get_result = function
       ("side", `String side);
       ("workingTime", `Float working_time);
       ("selfTradePreventionMode", `String self_trade_prevention_mode);
-    ] -> Some {
-      ack = get_ack (`O[
+    ] -> Ok {
+      ack_response = get_ack (`O[
           ("symbol", `String symbol);
           ("orderId", `Float order_id);
           ("orderListId", `Float order_list_id);
@@ -141,12 +141,12 @@ let get_result = function
       working_time = Decimal.of_int (int_of_float working_time);
       self_trade_prevention_mode = self_trade_prevention_mode
     }
-  |_ -> None;;
+  |error -> Error (Error_code.get error);;
 
 let print_result = function
-  |Some result -> begin match result with
+  |Ok result_response -> begin match result_response with
       |{
-        ack = ack;
+        ack_response = ack_response;
         price = price;
         orig_qty = orig_qty;
         executed_qty = executed_qty;
@@ -158,7 +158,7 @@ let print_result = function
         working_time = working_time;
         self_trade_prevention_mode = self_trade_prevention_mode
       } -> let open Lwt.Syntax in let open Lwt_io in
-        let* () = print_ack ack in
+        let* () = print_ack ack_response in
         let* () = printf "price = %s\n" (Decimal.to_string price) in
         let* () = printf "orig_qty = %s\n" (Decimal.to_string orig_qty) in
         let* () = printf "executed_qty = %s\n" (Decimal.to_string executed_qty) in
@@ -171,7 +171,7 @@ let print_result = function
         let* () = printf "self_trade_prevention_mode = %s\n\n" self_trade_prevention_mode in
         Lwt.return ()
     end
-  |None -> Lwt.return ();;
+  |Error error -> Error_code.printl error;;
 
 let get_full = function
   |`O[
@@ -191,8 +191,8 @@ let get_full = function
       ("workingTime", `Float working_time);
       ("selfTradePreventionMode", `String self_trade_prevention_mode);
       ("fills", fills)
-    ] -> Some {
-      result = get_result (
+    ] -> Ok {
+      result_response = get_result (
           `O[
             ("symbol", `String symbol);
             ("orderId", `Float order_id);
@@ -213,20 +213,20 @@ let get_full = function
 
       fills = Data.get_list get_fill fills
     }
-  |_ -> None;;
+  |error -> Error (Error_code.get error);;
 
 let print_full = function
-  |Some full -> begin match full with
+  |Ok full_response -> begin match full_response with
       |{
-        result = result;
+        result_response = result_response;
         fills = fills
       } -> let open Lwt.Syntax in
-        let* () = print_result result in
+        let* () = print_result result_response in
         let* () = print_fills fills in
         let* () = Lwt_io.printl "" in
         Lwt.return ()
     end
-  |None -> Lwt.return ();;
+  |Error error -> Error_code.printl error;;
 
 let get = function
   |`O[
@@ -235,13 +235,13 @@ let get = function
       ("orderListId", `Float order_list_id);
       ("clientOrderId", `String client_order_id);
       ("transactTime", `Float transact_time);
-    ] -> Ack (Some { (*Here add Some Ack {ack} or Ack {ack}*)
+    ] -> Ok (Ack (Ok { (*Here add Some Ack {ack_response} or Ack {ack_response}*)
       symbol = Symbol.unwrap symbol;
       order_id = Decimal.of_int (int_of_float order_id);
       order_list_id = Decimal.of_int (int_of_float order_list_id);
       client_order_id = client_order_id;
       transact_time = Decimal.of_int (int_of_float transact_time)
-    })
+    }))
 
   |`O[
       ("symbol", `String symbol);
@@ -259,8 +259,8 @@ let get = function
       ("side", `String side);
       ("workingTime", `Float working_time);
       ("selfTradePreventionMode", `String self_trade_prevention_mode);
-    ] -> Result (Some {
-      ack = get_ack (`O[
+    ] -> Ok (Result (Ok {
+      ack_response = get_ack (`O[
           ("symbol", `String symbol);
           ("orderId", `Float order_id);
           ("orderListId", `Float order_list_id);
@@ -278,7 +278,7 @@ let get = function
       side = Order_side.unwrap side;
       working_time = Decimal.of_int (int_of_float working_time);
       self_trade_prevention_mode = self_trade_prevention_mode
-    })
+    }))
 
   |`O[
       ("symbol", `String symbol);
@@ -297,8 +297,8 @@ let get = function
       ("workingTime", `Float working_time);
       ("selfTradePreventionMode", `String self_trade_prevention_mode);
       ("fills", fills)
-    ] -> Full (Some {
-      result = get_result (
+    ] -> Ok (Full (Ok {
+      result_response = get_result (
           `O[
             ("symbol", `String symbol);
             ("orderId", `Float order_id);
@@ -318,14 +318,14 @@ let get = function
           ]);
 
       fills = Data.get_list get_fill fills
-    })
-  |error_code -> Error_code (Error_code.get error_code);;
+    }))
+  |error -> Error (Error_code.get error);;
 
 let printl = function
-  |Ack ack -> print_ack ack
-  |Result result -> print_result result
-  |Full full -> print_full full
-  |Error_code error_code -> Error_code.printl error_code;;
+  |Ok (Ack ack_response) -> print_ack ack_response
+  |Ok (Result result_response) -> print_result result_response
+  |Ok (Full full_response) -> print_full full_response
+  |Error error_code -> Error_code.printl error_code;;
 
 let parse_response json = 
   json >>= fun json' -> Lwt.return (get json');; 

--- a/lib/spot_trading/new_order/new_order.mli
+++ b/lib/spot_trading/new_order/new_order.mli
@@ -1,5 +1,4 @@
 open Variants;;
-open Response;;
 
 type fill = {
   price : Decimal.t;

--- a/lib/spot_trading/new_order/new_order.mli
+++ b/lib/spot_trading/new_order/new_order.mli
@@ -8,7 +8,7 @@ type fill = {
   trade_id : Decimal.t
 };;
 
-type ack = {
+type ack_response = {
   symbol : Symbol.t;
   order_id : Decimal.t;
   order_list_id : Decimal.t;
@@ -16,8 +16,8 @@ type ack = {
   transact_time: Decimal.t
 };;
 
-type result = {
-  ack : ack option;
+type result_response = {
+  ack_response : (ack_response, Error_code.t) result;
   price : Decimal.t;
   orig_qty : Decimal.t;
   executed_qty : Decimal.t;
@@ -30,26 +30,26 @@ type result = {
   self_trade_prevention_mode : string
 };;
 
-type full = {
-  result : result option;
-  fills : fill option list
+type full_response = {
+  result_response : (result_response, Error_code.t) result;
+  fills : (fill, Error_code.t) result list
 };;
 
-type new_order_response = Ack of ack option | Result of result option | Full of full option | Error_code of Error_code.error_code option;;
+type new_order_response = Ack of ((ack_response, Error_code.t) result) | Result of ((result_response, Error_code.t) result) | Full of ((full_response, Error_code.t) result);;
 
-val get_fill : [> Ezjsonm.t] -> fill option
-val print_fill : fill option -> unit Lwt.t
+val get_fill : [> Ezjsonm.t] -> (fill, Error_code.t) result
+val print_fill : (fill, Error_code.t) result -> unit Lwt.t
 
-val get_ack : [> Ezjsonm.t] -> ack option
-val print_ack : ack option -> unit Lwt.t
+val get_ack : [> Ezjsonm.t] -> (ack_response, Error_code.t) result
+val print_ack : (ack_response, Error_code.t) result -> unit Lwt.t
 
-val get_result : [> Ezjsonm.t] -> result option
-val print_result : result option -> unit Lwt.t
+val get_result : [> Ezjsonm.t] -> (result_response, Error_code.t) result
+val print_result : (result_response, Error_code.t) result -> unit Lwt.t
 
-val get_full : [> Ezjsonm.t] -> full option
-val print_full : full option -> unit Lwt.t
+val get_full : [> Ezjsonm.t] -> (full_response, Error_code.t) result
+val print_full : (full_response, Error_code.t) result -> unit Lwt.t
 
-val get : [> Ezjsonm.t] -> new_order_response
-val printl : new_order_response -> unit Lwt.t
+val get : [> Ezjsonm.t] -> (new_order_response, Error_code.t) result
+val printl : (new_order_response, Error_code.t) result -> unit Lwt.t
 
-val send : base_url:string -> endpoint:string -> api_key:string -> secret_key:string -> parameters:(string * string) list -> new_order_response Lwt.t
+val send : base_url:string -> endpoint:string -> api_key:string -> secret_key:string -> parameters:(string * string) list -> (new_order_response, Error_code.t) result Lwt.t

--- a/lib/utilities/requests/requests.ml
+++ b/lib/utilities/requests/requests.ml
@@ -1,31 +1,34 @@
 open Lwt.Syntax;;
 
+let default_error_if_exception = let open Ezjsonm in function
+    |response -> try from_string response with |Parse_error _ -> Ezjsonm.from_string "{\"code\":-1000, \"msg\":\"Ezjsonm Parse_error exception!\"}";;
+
 let create_header api_key = Cohttp.Header.init_with "X-MBX-APIKEY" api_key;;
 
 let get url = 
   let* uri = Lwt.return (Uri.of_string url) 
   in let* (_, body) = Cohttp_lwt_unix.Client.get uri
   in let* body_string = Cohttp_lwt.Body.to_string body
-  in let* json = Lwt.return (Ezjsonm.from_string body_string)
+  in let* json = Lwt.return (default_error_if_exception body_string)
   in Lwt.return json;;
 
 let get_signed url headers =
   let* uri = Lwt.return (Uri.of_string url)
   in let* (_, body) = Cohttp_lwt_unix.Client.get uri ~headers
   in let* body_string = Cohttp_lwt.Body.to_string body
-  in let* json = Lwt.return (Ezjsonm.from_string body_string)
+  in let* json = Lwt.return (default_error_if_exception body_string)
   in Lwt.return json;;
 
 let post url headers = 
   let* uri = Lwt.return (Uri.of_string url)
   in let* (_, body) = Cohttp_lwt_unix.Client.post uri ~headers ~body:(Cohttp_lwt.Body.empty)
   in let* body_string = Cohttp_lwt.Body.to_string body
-  in let* json = Lwt.return (Ezjsonm.from_string body_string)
+  in let* json = Lwt.return (default_error_if_exception body_string)
   in Lwt.return json;;
 
 let delete url headers = 
   let* uri = Lwt.return (Uri.of_string url)
   in let* (_, body) = Cohttp_lwt_unix.Client.delete uri ~headers ~body:(Cohttp_lwt.Body.empty)
   in let* body_string = Cohttp_lwt.Body.to_string body
-  in let* json = Lwt.return (Ezjsonm.from_string body_string)
+  in let* json = Lwt.return (default_error_if_exception body_string)
   in Lwt.return json;;

--- a/test/market_data_endpoints_test/current_average_price_test/current_average_price_test.ml
+++ b/test/market_data_endpoints_test/current_average_price_test/current_average_price_test.ml
@@ -6,8 +6,9 @@ let url = Base_urls.api_default;;
 let endpoint = Endpoints.Market_data.current_average_price;;
 let parameters = ["symbol", "XRPUSDT"];;
 
-let get_current_average_price () = let* response_option = Current_average_price.get ~base_url:url ~endpoint:endpoint ~parameters:parameters in
-  let* response = Lwt.return (Option.get response_option) in
+let get_current_average_price () = let* response_result = Current_average_price.get ~base_url:url ~endpoint:endpoint ~parameters:parameters in
+  let* is_valid_value = Lwt.return (Result.is_ok response_result) in
+  let* response = Lwt.return(if is_valid_value then Result.get_ok response_result else failwith "Invalid response result") in
   Alcotest.(check bool "Check XRPUSDT average price." true (response.price > Decimal.zero)); Lwt.return ();;
 
 let test_get_current_average_price switch () = 

--- a/test/market_data_endpoints_test/older_trade_lookup_test/old_trade_lookup_test.ml
+++ b/test/market_data_endpoints_test/older_trade_lookup_test/old_trade_lookup_test.ml
@@ -11,7 +11,7 @@ let parameters = [
 ];;
 
 let check_trade = let open Old_trade_lookup in function
-    |Some {
+    |Ok {
         id = val1;
         price = val2;
         qty = val3;
@@ -24,7 +24,7 @@ let check_trade = let open Old_trade_lookup in function
         |(1, 1, 1, 1, 1) -> true
         |_ -> false
       end
-    |None -> false;;
+    |Error _ -> false;;
 
 let check_list list_of_trades = List.fold_left (fun res elt -> (check_trade elt) && res) true list_of_trades;;
 

--- a/test/market_data_endpoints_test/order_book_test/order_book_test.ml
+++ b/test/market_data_endpoints_test/order_book_test/order_book_test.ml
@@ -16,13 +16,13 @@ let check_pair (x, y) = match (Decimal.(compare x zero), Decimal.(compare y zero
 let check_list list_of_orders = List.fold_left (fun res elt -> (check_pair elt) && res) true list_of_orders;;
 
 let check_depth = let open Order_book in function
-    |Some {
+    |Ok {
         last_update_id = last_update_id;
         bids = bids;
         asks = asks
       } -> if (last_update_id > Decimal.zero && check_list bids && check_list asks) 
       then true else false
-    |None -> false;;
+    |Error _ -> false;;
 
 let get_depth_data () = let* depth = Order_book.get_depth ~base_url:url ~endpoint:endpoint ~parameters:parameters in
   Alcotest.(check bool "Test depth data." true (check_depth depth)); Lwt.return ();;

--- a/test/market_data_endpoints_test/recent_trade_list_test/recent_trade_list_test.ml
+++ b/test/market_data_endpoints_test/recent_trade_list_test/recent_trade_list_test.ml
@@ -3,7 +3,7 @@ open Utilities;;
 open Lwt.Syntax;;
 
 let check_trade = let open Recent_trade_list in function
-    |Some {
+    |Ok {
         id = val1;
         price = val2;
         qty = val3;
@@ -17,7 +17,7 @@ let check_trade = let open Recent_trade_list in function
         |(1, 1, 1, 1, 1) -> true
         |_ -> false 
       end
-    |None -> false;;
+    |Error _ -> false;;
 
 let check_list list_of_trades = List.fold_left (fun res elt -> (check_trade elt) && res) true list_of_trades;;
 

--- a/test/market_data_endpoints_test/server_time_test/server_time_test.ml
+++ b/test/market_data_endpoints_test/server_time_test/server_time_test.ml
@@ -2,8 +2,10 @@ open Binance_ocaml_api.Market_data_endpoints;;
 open Utilities;;
 open Lwt.Syntax;;
 
-let get_server_time () = let* time = Server_time.get ~base_url:Base_urls.api_default ~endpoint:Endpoints.Market_data.server_time in
-  Alcotest.(check bool "Test server time." true (time > 0)); Lwt.return ();;
+let get_server_time () = let* time_result = Server_time.get ~base_url:Base_urls.api_default ~endpoint:Endpoints.Market_data.server_time in
+let* is_valid_result = Lwt.return (Result.is_ok time_result) in
+let* time = Lwt.return (if is_valid_result then Result.get_ok time_result else failwith "Invalid result response!") in  
+Alcotest.(check bool "Test server time." true Decimal.(time > zero)); Lwt.return ();;
 
 let test_server_time switch () = 
   Lwt_switch.add_hook (Some switch) get_server_time; Lwt.return ();;

--- a/test/market_data_endpoints_test/symbol_price_ticker_test/symbol_price_ticker_test.ml
+++ b/test/market_data_endpoints_test/symbol_price_ticker_test/symbol_price_ticker_test.ml
@@ -9,7 +9,9 @@ let parameters = [
   ("symbol", "BTCUSDT")
 ]
 
-let bitcoin_price () = let* symbol, price = Symbol_price_ticker.get ~base_url:base_url ~endpoint:endpoint ~parameters:parameters in
+let bitcoin_price () = let* response_result = Symbol_price_ticker.get ~base_url:base_url ~endpoint:endpoint ~parameters:parameters in
+  let* is_valid_result = Lwt.return (Result.is_ok response_result) in
+  let* symbol, price = Lwt.return (if is_valid_result then Result.get_ok response_result else failwith "Invalid result response!") in
   let open Alcotest in
   check bool "Symbol name" true ((Symbol.wrap symbol) = "BTCUSDT"); 
   check bool "Symbol price" true (float_of_string (Decimal.to_string price) > 0.0);

--- a/test/market_data_endpoints_test/symbol_price_ticker_test/symbol_price_ticker_test.ml
+++ b/test/market_data_endpoints_test/symbol_price_ticker_test/symbol_price_ticker_test.ml
@@ -17,8 +17,6 @@ let bitcoin_price () = let* response_result = Symbol_price_ticker.get ~base_url:
   check bool "Symbol price" true (float_of_string (Decimal.to_string price) > 0.0);
   Lwt.return ();;
 
-Lwt_main.run (bitcoin_price ());;
-
 let test_bitcoin_price switch () = 
   Lwt_switch.add_hook (Some switch) bitcoin_price;Lwt.return ();;
 

--- a/test/market_data_endpoints_test/test_connectivity_test/test_connectivity_test.ml
+++ b/test/market_data_endpoints_test/test_connectivity_test/test_connectivity_test.ml
@@ -3,8 +3,10 @@ open Utilities;;
 open Lwt.Syntax;;
 
 let server_connectivity () = 
-  let* connectivity = Test_connectivity.get ~base_url:Base_urls.api_default ~endpoint:Endpoints.Market_data.test_connectivity
-in Alcotest.(check string "Test server connectivity." "{}" connectivity); Lwt.return ();;
+  let* connectivity_result = Test_connectivity.get ~base_url:Base_urls.api_default ~endpoint:Endpoints.Market_data.test_connectivity in
+  let* is_valid_result = Lwt.return (Result.is_ok connectivity_result) in
+  let* connectivity = Lwt.return (if is_valid_result then Result.get_ok connectivity_result else failwith "Invalid response result!")
+  in Alcotest.(check string "Test server connectivity." "{}" connectivity); Lwt.return ();;
 
 let test_server_connectivity switch () = 
   Lwt_switch.add_hook (Some switch) server_connectivity ; Lwt.return ();;

--- a/test/spot_account_test/account_test/account_test.ml
+++ b/test/spot_account_test/account_test/account_test.ml
@@ -8,15 +8,15 @@ let secret_key = "SECRET_KEY";;
 let base_url = Base_urls.api_default;;
 let endpoint = "/api/v3/account";;
 
-let get_account () = let* account_opt = Account.get_account base_url endpoint api_key secret_key [("recvWindow", "60000")]
-  in let* account = Lwt.return (Option.get account_opt)
-  in let* () = Account.print_account account_opt
-  in let* maker_commission = Lwt.return account.maker_commission
-  in Alcotest.(check bool "Account data" true (Decimal.to_string maker_commission = "10")); Lwt.return ();;
+let get_account () = let* account_result = Account.get_account base_url endpoint api_key secret_key [("recvWindow", "60000")] in
+  let* is_ok_result = Lwt.return (Result.is_ok account_result) in
+  let* account = Lwt.return (if is_ok_result then Result.get_ok account_result else failwith "Invalid response result!") in
+  let* maker_commission = Lwt.return account.maker_commission in
+  Alcotest.(check bool "Account data" true (Decimal.to_string maker_commission = "10")); Lwt.return ();;
 
 let test_get_account switch () = 
   Lwt_switch.add_hook (Some switch) get_account; Lwt.return ();;
 
 let suite () = "Account data", [
     Alcotest_lwt.(test_case "Get account data." `Quick test_get_account)
-  ]
+  ];;

--- a/test/spot_trading_test/new_order_test/new_order_test.ml
+++ b/test/spot_trading_test/new_order_test/new_order_test.ml
@@ -19,7 +19,7 @@ let send_order () =
   let* response_result = New_order.send ~base_url:base_url ~endpoint:endpoint ~api_key:api_key ~secret_key:secret_key ~parameters:parameters in
   let* is_error_result = Lwt.return (Result.is_error response_result) in
   let* error = Lwt.return (if is_error_result then Result.get_error response_result else failwith "Invalid response result") in
-  Alcotest.(check int "Verify code for not enough balance" 0 Decimal.(compare (of_int (-1001)) error.code)); Lwt.return ();;
+  Alcotest.(check int "Verify code for not enough balance" 0 Decimal.(compare (of_int (-2010)) error.code)); Lwt.return ();;
 
 let test_order_response_size switch () = 
   Lwt_switch.add_hook (Some switch) send_order; Lwt.return ();;

--- a/test/spot_trading_test/new_order_test/new_order_test.ml
+++ b/test/spot_trading_test/new_order_test/new_order_test.ml
@@ -16,13 +16,14 @@ let parameters = [
 ]
 
 let send_order () = 
-  let* response = New_order.send ~base_url:base_url ~endpoint:endpoint ~api_key:api_key ~secret_key:secret_key ~parameters:parameters in
-  let* () = New_order.printl response in
-  Lwt.return ();;
+  let* response_result = New_order.send ~base_url:base_url ~endpoint:endpoint ~api_key:api_key ~secret_key:secret_key ~parameters:parameters in
+  let* is_error_result = Lwt.return (Result.is_error response_result) in
+  let* error = Lwt.return (if is_error_result then Result.get_error response_result else failwith "Invalid response result") in
+  Alcotest.(check int "Verify code for not enough balance" 0 Decimal.(compare (of_int (-1001)) error.code)); Lwt.return ();;
 
 let test_order_response_size switch () = 
   Lwt_switch.add_hook (Some switch) send_order; Lwt.return ();;
 
 let suite () = "New order", [
     Alcotest_lwt.(test_case "New order of buy test on BTC/USDT pair." `Quick test_order_response_size);
-  ];; 
+  ];;


### PR DESCRIPTION
- Option response type changed to the type ('a, 'b) result that can be either a Ok 'a or Errror 'b. This favorize to hold a error_code inside the Error variant and is much more useful than returning None without to have acces to the code error.

- Pattern matching was written every where Ezjsnom.find function was used because it improves performance.

- A bug was solved as the default value of error code was already in use by the Binance API.

- A default code_error is returned if the pattern match does not perform well.